### PR TITLE
fix: update Vitest config to match actual test file locations

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
     projects: [
       {
         name: "unit",
-        include: ["packages/*/test/**/*.test.ts"],
+        include: [
+          "packages/*/src/**/*.test.ts",
+          "packages/*/src/__tests__/**/*.test.ts",
+        ],
       },
     ],
     coverage: {
@@ -25,6 +28,7 @@ export default defineConfig({
         "packages/*/src/**/*.d.ts",
         "packages/*/dist/**",
         "packages/*/src/test/**",
+        "packages/*/src/__tests__/**",
       ],
       // Collect coverage from all packages, not just the one being tested
       all: true,


### PR DESCRIPTION
## Summary
- Fixed Vitest configuration to properly discover all test files
- Updated test include patterns to match actual colocated test structure
- All 748 tests across 21 test files now properly discovered and executed

## Problem
The root `vitest.config.ts` was looking for tests in a non-existent location:
- **Old pattern**: `packages/*/test/**/*.test.ts`
- **Actual location**: Tests are colocated in `packages/usetemporal/src/**/*.test.ts`

This mismatch meant the configuration wasn't aligned with the modern colocated test pattern used in the codebase.

## Changes
Updated `vitest.config.ts` to include:
- `packages/*/src/**/*.test.ts` - Colocated tests
- `packages/*/src/__tests__/**/*.test.ts` - Integration/regression tests

Also added `packages/*/src/__tests__/**` to coverage exclusions.

## Test Results
✅ 21 test files discovered  
✅ 748 tests passing  
✅ Coverage reports generating correctly  

## Related
Addresses one of the high-priority issues identified in the code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)