### PR TITLE
feat: add Vue createTemporal provider

### DIFF
--- a/examples/vue/src/composables/useTemporal.ts
+++ b/examples/vue/src/composables/useTemporal.ts
@@ -1,8 +1,8 @@
-import { useTemporal } from '@allystudio/usetemporal-vue'
+import { createTemporal } from '@allystudio/usetemporal-vue'
 import { createNativeAdapter } from '@allystudio/usetemporal/native'
 
 // Create a single shared temporal instance
-export const temporal = useTemporal({
+export const temporal = createTemporal({
   date: new Date(),
   adapter: createNativeAdapter({ weekStartsOn: 1 }),
   weekStartsOn: 1, // Monday

--- a/package-lock.json
+++ b/package-lock.json
@@ -2623,9 +2623,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
-      "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.50.tgz",
+      "integrity": "sha512-5e76wQiQVeL1ICOZVUg4LSOVYg9jyhGCin+icYozhsUzM+fHE7kddi1bdiE0jwVqTfkjba3jUFbEkoC9WkdvyA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3409,13 +3409,13 @@
       "link": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.0.tgz",
-      "integrity": "sha512-iAliE72WsdhjzTOp2DtvKThq1VBC4REhwRcaA+zPAAph6I+OQhUXv+Xu2KS7ElxYtb7Zc/3R30Hwv1DxEo7NXQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.2.tgz",
+      "integrity": "sha512-iHmwV3QcVGGvSC1BG5bZ4z6iwa1SOpAPWmnjOErd4Ske+lZua5K9TtAVdx0gMBClJ28DViCbSmZitjWZsWO3LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-beta.19"
+        "@rolldown/pluginutils": "1.0.0-beta.50"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -8402,6 +8402,7 @@
       "devDependencies": {
         "@types/node": "^22.12.1",
         "@usetemporal/tsconfig": "^2.0.0-alpha.1",
+        "@vitejs/plugin-vue": "^6.0.2",
         "typescript": "^5.7.3",
         "vite": "^7.2.4",
         "vite-plugin-dts": "^4.4.0",

--- a/packages/usetemporal-vue/README.md
+++ b/packages/usetemporal-vue/README.md
@@ -21,17 +21,21 @@ npm install @allystudio/usetemporal/native
 
 ```ts
 import { ref } from "vue";
-import { useTemporal, usePeriod } from "@allystudio/usetemporal-vue";
+import { createTemporal, useTemporal, usePeriod } from "@allystudio/usetemporal-vue";
 import { createNativeAdapter } from "@allystudio/usetemporal/native";
 
 const now = ref(new Date());
 
-const temporal = useTemporal({
+// Call inside setup to create + provide the temporal instance
+const temporal = createTemporal({
   adapter: createNativeAdapter(),
   date: now,
 });
 
 const month = usePeriod(temporal, "month");
+
+// Child components can access the same instance via the injector:
+const nestedTemporal = useTemporal();
 
 month.value.start; // Reactive!
 ```
@@ -40,11 +44,11 @@ month.value.start; // Reactive!
 
 ```ts
 import { computed, ref } from "vue";
-import { useTemporal } from "@allystudio/usetemporal-vue";
+import { createTemporal } from "@allystudio/usetemporal-vue";
 import { createNativeAdapter } from "@allystudio/usetemporal/native";
 
 const weekStartsOn = ref(1);
-const temporal = useTemporal({
+const temporal = createTemporal({
   adapter: computed(() =>
     createNativeAdapter({ weekStartsOn: weekStartsOn.value })
   ),
@@ -56,10 +60,15 @@ weekStartsOn.value = 0; // automatically recalculates browsing periods
 
 ### API
 
-- `useTemporal(options: UseTemporalOptions): TemporalBuilder`  
-  Creates a reactive temporal instance. Options accept native dates or refs for
-  both `date` and `now`. Methods from the builder delegate to the core
-  operations while passing the adapter automatically.
+- `createTemporal(options: CreateTemporalOptions): TemporalBuilder`  
+  Creates (and automatically provides) a reactive temporal instance. Options
+  accept native dates or refs for both `date` and `now`. Methods from the
+  builder delegate to the core operations while passing the adapter
+  automatically.
+
+- `useTemporal(): TemporalBuilder`  
+  Injects the nearest provided temporal instance so nested components can tap
+  into the same builder without prop drilling.
 
 - `usePeriod(temporal: VueTemporal, unit: Unit | Ref<Unit>): ComputedRef<Period>`  
   Returns a computed period that updates when `browsing` changes or the unit
@@ -74,9 +83,9 @@ import { createTemporal, usePeriod } from "@allystudio/usetemporal";
 const temporal = createTemporal({ adapter, date: new Date() });
 
 // After
-import { useTemporal, usePeriod } from "@allystudio/usetemporal-vue";
+import { createTemporal, usePeriod } from "@allystudio/usetemporal-vue";
 
-const temporal = useTemporal({ adapter, date: new Date() });
+const temporal = createTemporal({ adapter, date: new Date() });
 ```
 
 ## Scripts
@@ -84,6 +93,19 @@ const temporal = useTemporal({ adapter, date: new Date() });
 - `npm run build --workspace=@allystudio/usetemporal-vue`
 - `TZ=UTC npm test --workspace=@allystudio/usetemporal-vue`
 - `npm run type-check --workspace=@allystudio/usetemporal-vue`
+- `npm run demo --workspace=@allystudio/usetemporal-vue`
+
+## Demo playground
+
+Run the interactive playground directly from this workspace to experiment with
+the composables:
+
+```bash
+npm run demo --workspace=@allystudio/usetemporal-vue
+```
+
+The Vite app lives under `packages/usetemporal-vue/demo` and imports the
+library source directly, so any local changes are reflected instantly.
 
 ## Documentation
 

--- a/packages/usetemporal-vue/demo/env.d.ts
+++ b/packages/usetemporal-vue/demo/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/usetemporal-vue/demo/index.html
+++ b/packages/usetemporal-vue/demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>useTemporal Vue Demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/usetemporal-vue/demo/src/App.vue
+++ b/packages/usetemporal-vue/demo/src/App.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from "vue";
+import type { Period } from "@allystudio/usetemporal";
+import { createTemporal, usePeriod } from "@allystudio/usetemporal-vue";
+import { createNativeAdapter } from "@allystudio/usetemporal/native";
+import StableMonthView from "./components/StableMonthView.vue";
+import YearView from "./components/YearView.vue";
+import WeekView from "./components/WeekView.vue";
+import WorkweekView from "./components/WorkweekView.vue";
+import DayView from "./components/DayView.vue";
+
+const weekStartsOn = ref(1);
+const weekStartSignal = ref(weekStartsOn.value);
+const unit = ref<"week" | "month">("month");
+
+const temporal = createTemporal({
+  adapter: createNativeAdapter({ weekStartsOn: weekStartsOn.value }),
+  date: new Date(),
+});
+
+watch(weekStartsOn, (value) => {
+  temporal.adapter = createNativeAdapter({ weekStartsOn: value });
+  temporal.weekStartsOn = value;
+  weekStartSignal.value = value;
+  const current = browsing.value;
+  browsing.value = temporal.period(current.date, current.type);
+});
+
+const browsing = temporal.browsing;
+const activeUnit = computed(() => unit.value);
+
+const baseActivePeriod = usePeriod(temporal, activeUnit);
+const baseDayPeriod = usePeriod(temporal, "day");
+const baseWeekPeriod = usePeriod(temporal, "week");
+const baseMonthPeriod = usePeriod(temporal, "month");
+const baseYearPeriod = usePeriod(temporal, "year");
+
+const activePeriod = computed(() => {
+  weekStartSignal.value;
+  return baseActivePeriod.value;
+});
+const dayPeriod = computed(() => {
+  weekStartSignal.value;
+  return baseDayPeriod.value;
+});
+const weekPeriod = computed(() => {
+  weekStartSignal.value;
+  return baseWeekPeriod.value;
+});
+const monthPeriod = computed(() => {
+  weekStartSignal.value;
+  return baseMonthPeriod.value;
+});
+const yearPeriod = computed(() => {
+  weekStartSignal.value;
+  return baseYearPeriod.value;
+});
+
+const todayPeriod = computed(() => temporal.now.value);
+
+const detailDays = computed(() => {
+  weekStartSignal.value;
+  return temporal.divide(activePeriod.value, "day");
+});
+
+const monthWeeks = computed(() => {
+  weekStartSignal.value;
+  const month = monthPeriod.value;
+  const firstWeek = temporal.period(month.start, "week");
+  return Array.from({ length: 6 }, (_, index) => {
+    const period = index === 0 ? firstWeek : temporal.go(firstWeek, index);
+    return {
+      period,
+      days: temporal.divide(period, "day"),
+    };
+  });
+});
+
+const formatter = reactive({
+  header: new Intl.DateTimeFormat("en", { month: "long", year: "numeric" }),
+  detail: new Intl.DateTimeFormat("en", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  }),
+  range: new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }),
+});
+
+const todayLabel = computed(() => formatter.detail.format(todayPeriod.value.date));
+const activeRangeLabel = computed(() => {
+  weekStartSignal.value;
+  return `${formatter.range.format(activePeriod.value.start)} – ${formatter.range.format(
+    activePeriod.value.end
+  )}`;
+});
+const unitLabel = computed(() => (unit.value === "week" ? "Week" : "Month"));
+
+function shift(step: number) {
+  browsing.value = temporal.go(activePeriod.value, step);
+}
+
+function resetToToday() {
+  browsing.value = temporal.period(new Date(), "day");
+}
+
+function selectDay(day: Period) {
+  browsing.value = day;
+}
+
+function selectMonth(month: Period) {
+  browsing.value = month;
+  unit.value = "month";
+}
+</script>
+
+<template>
+  <div class="calendar-shell">
+    <div class="calendar-app">
+      <header class="calendar-header">
+        <div class="header-meta">
+          <p class="eyebrow">Today · {{ todayLabel }}</p>
+          <h1>{{ formatter.header.format(monthPeriod.start) }}</h1>
+        </div>
+        <div class="primary-controls">
+          <div class="nav-controls">
+            <button class="nav-button" @click="shift(-1)">‹</button>
+            <button class="nav-button" @click="resetToToday()">Today</button>
+            <button class="nav-button" @click="shift(1)">›</button>
+          </div>
+          <div class="segment-control">
+            <button :class="{ active: unit === 'month' }" @click="unit = 'month'">
+              Month
+            </button>
+            <button :class="{ active: unit === 'week' }" @click="unit = 'week'">
+              Week
+            </button>
+          </div>
+          <label class="weekstart">
+            Week starts on
+            <input v-model.number="weekStartsOn" type="number" min="0" max="6" />
+          </label>
+        </div>
+      </header>
+
+      <main class="calendar-main">
+        <StableMonthView
+          :month="monthPeriod"
+          :selected="activePeriod"
+          :today="todayPeriod"
+          :week-starts-on="weekStartsOn"
+          :active-unit="unit"
+          :weeks="monthWeeks"
+          @select="selectDay"
+        />
+
+        <section class="panel-grid">
+          <YearView :year="yearPeriod" :month="monthPeriod" @select="selectMonth" />
+          <WeekView :week="weekPeriod" :selected="browsing" @select="selectDay" />
+          <WorkweekView :week="weekPeriod" />
+          <DayView :day="dayPeriod" />
+          <section class="panel-card detail-panel">
+            <div class="detail-header">
+              <p class="eyebrow">{{ unitLabel }} overview</p>
+              <h2>{{ activeRangeLabel }}</h2>
+            </div>
+            <p class="detail-note">
+              Derived from <code>usePeriod(temporal, unit)</code> with
+              <code>temporal.divide(period, "day")</code>.
+            </p>
+            <div class="detail-days">
+              <article v-for="day in detailDays" :key="day.start.toISOString()" class="detail-card">
+                <span class="mini-label">
+                  {{ day.start.toLocaleDateString("en", { weekday: "short" }) }}
+                </span>
+                <strong>
+                  {{ day.start.toLocaleDateString("en", { month: "long", day: "numeric" }) }}
+                </strong>
+                <small>Unit: {{ day.type }}</small>
+              </article>
+            </div>
+          </section>
+        </section>
+      </main>
+    </div>
+  </div>
+</template>

--- a/packages/usetemporal-vue/demo/src/components/DayView.vue
+++ b/packages/usetemporal-vue/demo/src/components/DayView.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Period } from "@allystudio/usetemporal";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+
+const props = defineProps<{
+  day: Period;
+}>();
+
+const temporal = useTemporal();
+const hours = computed(() => temporal.divide(props.day, "hour"));
+
+const guideSlots = computed(() =>
+  hours.value.filter((_, index) => index % 3 === 0).map((slot) => slot.start)
+);
+
+const friendlyDate = computed(() =>
+  props.day.start.toLocaleDateString("en", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  })
+);
+</script>
+
+<template>
+  <section class="panel-card day-view">
+    <header>
+      <p class="eyebrow">Day focus</p>
+      <h3>{{ friendlyDate }}</h3>
+    </header>
+    <div class="day-timeline">
+      <div v-for="timestamp in guideSlots" :key="timestamp.toISOString()" class="timeline-row">
+        <span class="time">{{ timestamp.toLocaleTimeString("en", { hour: "numeric" }) }}</span>
+        <div class="slot"></div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/packages/usetemporal-vue/demo/src/components/StableMonthView.vue
+++ b/packages/usetemporal-vue/demo/src/components/StableMonthView.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { Period } from "@allystudio/usetemporal";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+import WeekNamesView from "./WeekNamesView.vue";
+
+const props = defineProps<{
+  month: Period;
+  selected: Period;
+  today: Period;
+  weekStartsOn: number;
+  activeUnit: "week" | "month";
+  weeks: Array<{ period: Period; days: Period[] }>;
+}>();
+
+const emit = defineEmits<{ (e: "select", day: Period): void }>();
+
+const temporal = useTemporal();
+
+const isToday = (day: Period) => temporal.contains(day, props.today.date);
+const isSelectedDay = (day: Period) => temporal.contains(day, props.selected);
+const isInsideSelection = (day: Period) => temporal.contains(props.selected, day);
+const isOutsideMonth = (day: Period) => day.start.getMonth() !== props.month.start.getMonth();
+const isActiveWeek = (week: Period) =>
+  props.activeUnit === "week" && temporal.contains(props.selected, week);
+
+function selectDay(day: Period) {
+  emit("select", day);
+}
+</script>
+
+<template>
+  <section class="month-view">
+    <WeekNamesView :week-starts-on="weekStartsOn" />
+    <div
+      v-for="week in weeks"
+      :key="week.period.start.toISOString()"
+      class="week-row"
+      :class="{ active: isActiveWeek(week.period) }"
+    >
+      <button
+        v-for="day in week.days"
+        :key="day.start.toISOString()"
+        class="day-cell"
+        :class="{
+          today: isToday(day),
+          selected: isSelectedDay(day),
+          outside: isOutsideMonth(day),
+          focus: isInsideSelection(day),
+        }"
+        @click="selectDay(day)"
+      >
+        <span class="number">{{ day.start.getDate() }}</span>
+        <span class="weekday">{{ day.start.toLocaleDateString("en", { weekday: "short" }) }}</span>
+      </button>
+    </div>
+  </section>
+</template>

--- a/packages/usetemporal-vue/demo/src/components/WeekNamesView.vue
+++ b/packages/usetemporal-vue/demo/src/components/WeekNamesView.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{ weekStartsOn: number }>();
+
+const labels = computed(() => {
+  const base = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const start = ((props.weekStartsOn % 7) + 7) % 7;
+  return Array.from({ length: 7 }, (_, idx) => base[(start + idx) % 7]);
+});
+</script>
+
+<template>
+  <div class="weekday-row">
+    <span v-for="label in labels" :key="label">{{ label }}</span>
+  </div>
+</template>

--- a/packages/usetemporal-vue/demo/src/components/WeekView.vue
+++ b/packages/usetemporal-vue/demo/src/components/WeekView.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Period } from "@allystudio/usetemporal";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+
+const props = defineProps<{
+  week: Period;
+  selected: Period;
+}>();
+
+const emit = defineEmits<{ (e: "select", day: Period): void }>();
+
+const temporal = useTemporal();
+const days = computed(() => temporal.divide(props.week, "day"));
+const isSelected = (day: Period) => temporal.contains(day, props.selected);
+
+function select(day: Period) {
+  emit("select", day);
+}
+</script>
+
+<template>
+  <section class="panel-card week-view">
+    <header>
+      <p class="eyebrow">Week view</p>
+      <h3>
+        {{ days[0]?.start.toLocaleDateString("en", { month: "short", day: "numeric" }) }}
+        –
+        {{ days[days.length - 1]?.start.toLocaleDateString("en", { month: "short", day: "numeric" }) }}
+      </h3>
+    </header>
+    <div class="week-strip">
+      <button
+        v-for="day in days"
+        :key="day.start.toISOString()"
+        class="week-day"
+        :class="{ active: isSelected(day) }"
+        @click="select(day)"
+      >
+        <span class="dow">{{ day.start.toLocaleDateString("en", { weekday: "short" }) }}</span>
+        <strong>{{ day.start.getDate() }}</strong>
+      </button>
+    </div>
+  </section>
+</template>

--- a/packages/usetemporal-vue/demo/src/components/WorkweekView.vue
+++ b/packages/usetemporal-vue/demo/src/components/WorkweekView.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Period } from "@allystudio/usetemporal";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+
+const props = defineProps<{
+  week: Period;
+}>();
+
+const temporal = useTemporal();
+const workingDays = computed(() =>
+  temporal.divide(props.week, "day").filter((day) => {
+    const dow = day.start.getDay();
+    return dow >= 1 && dow <= 5;
+  })
+);
+</script>
+
+<template>
+  <section class="panel-card workweek-view">
+    <header>
+      <p class="eyebrow">Workweek snapshot</p>
+      <h3>Mon – Fri</h3>
+    </header>
+    <div class="workweek-list">
+      <article v-for="day in workingDays" :key="day.start.toISOString()">
+        <strong>{{ day.start.toLocaleDateString("en", { weekday: "long" }) }}</strong>
+        <small>{{ day.start.toLocaleDateString("en", { month: "short", day: "numeric" }) }}</small>
+      </article>
+    </div>
+  </section>
+</template>

--- a/packages/usetemporal-vue/demo/src/components/YearView.vue
+++ b/packages/usetemporal-vue/demo/src/components/YearView.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Period } from "@allystudio/usetemporal";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+
+const props = defineProps<{
+  year: Period;
+  month: Period;
+}>();
+
+const emit = defineEmits<{ (e: "select", period: Period): void }>();
+
+const temporal = useTemporal();
+const yearPeriod = computed(() => props.year);
+const activeMonth = computed(() => props.month);
+
+const months = computed(() => temporal.divide(yearPeriod.value, "month"));
+
+const isActive = (month: Period) => temporal.contains(month, activeMonth.value);
+
+function select(month: Period) {
+  emit("select", month);
+}
+</script>
+
+<template>
+  <section class="panel-card year-view">
+    <header>
+      <p class="eyebrow">Year overview</p>
+      <h3>{{ yearPeriod.start.getFullYear() }}</h3>
+    </header>
+    <div class="year-grid">
+      <button
+        v-for="monthPeriod in months"
+        :key="monthPeriod.start.toISOString()"
+        class="month-chip"
+        :class="{ active: isActive(monthPeriod) }"
+        @click="select(monthPeriod)"
+      >
+        <span class="title">{{ monthPeriod.start.toLocaleDateString("en", { month: "short" }) }}</span>
+        <small>{{ temporal.divide(monthPeriod, "week").length }} weeks</small>
+      </button>
+    </div>
+  </section>
+</template>

--- a/packages/usetemporal-vue/demo/src/main.ts
+++ b/packages/usetemporal-vue/demo/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import "./style.css";
+
+createApp(App).mount("#app");

--- a/packages/usetemporal-vue/demo/src/style.css
+++ b/packages/usetemporal-vue/demo/src/style.css
@@ -1,0 +1,425 @@
+:root {
+  font-family: "SF Pro Display", "Inter", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: #0f172a;
+  background: #f7f8fb;
+  line-height: 1.4;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #fef6ff 0%, #f7fbff 60%, #f6f7fb 100%);
+  min-height: 100vh;
+}
+
+#app {
+  min-height: 100vh;
+  padding: 3.5rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.calendar-shell {
+  width: 100%;
+  max-width: 1100px;
+}
+
+.calendar-app {
+  background: #fff;
+  border-radius: 32px;
+  padding: 2.5rem;
+  box-shadow: 0 40px 120px rgba(15, 23, 42, 0.08),
+    0 20px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.calendar-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2.5rem;
+}
+
+.header-meta h1 {
+  font-size: clamp(2.25rem, 3vw, 3.25rem);
+  margin: 0.35rem 0 0;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.2em;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.primary-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.nav-controls {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.nav-button {
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  padding: 0.65rem 1.25rem;
+  font-size: 1rem;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.nav-button:hover {
+  border-color: #94a3b8;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.segment-control {
+  display: inline-flex;
+  background: #f1f5f9;
+  padding: 0.35rem;
+  border-radius: 999px;
+  gap: 0.2rem;
+}
+
+.segment-control button {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-weight: 600;
+  color: #475569;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.segment-control button.active {
+  background: #fff;
+  color: #0f172a;
+  box-shadow: 0 10px 30px rgba(148, 163, 184, 0.35);
+}
+
+.weekstart {
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  color: #475569;
+}
+
+.weekstart input {
+  margin-top: 0.25rem;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  padding: 0.35rem 0.75rem;
+  font-size: 1rem;
+  width: 120px;
+}
+
+.calendar-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.month-view {
+  background: linear-gradient(180deg, #fdfbff 0%, #fff 100%);
+  border-radius: 24px;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel-card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 24px;
+  padding: 1.5rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detail-panel {
+  min-height: 0;
+}
+
+.weekday-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  color: #94a3b8;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: 1rem;
+}
+
+.week-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.3rem;
+  margin-bottom: 0.45rem;
+  border-radius: 20px;
+  padding: 0.15rem;
+  transition: background 0.2s ease;
+}
+
+.week-row.active {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.day-cell {
+  aspect-ratio: 1 / 1;
+  border: none;
+  border-radius: 18px;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  padding: 0.65rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  position: relative;
+  color: #0f172a;
+}
+
+.day-cell:hover {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.day-cell .number {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.day-cell .weekday {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.day-cell.outside {
+  color: #cbd5f5;
+}
+
+.day-cell.today {
+  border: 1px solid rgba(99, 102, 241, 0.4);
+}
+
+.day-cell.focus {
+  background: rgba(15, 118, 214, 0.08);
+}
+
+.day-cell.selected {
+  background: #111827;
+  color: #fff;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.25);
+}
+
+.day-cell.selected .weekday {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.detail-header h2 {
+  margin: 0.3rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.detail-note {
+  color: #64748b;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.detail-days {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 460px;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.detail-card {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.9rem 1rem;
+  background: #fbfdff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.detail-card strong {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.detail-card small {
+  color: #94a3b8;
+}
+
+.mini-label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #a5b4fc;
+  letter-spacing: 0.2em;
+}
+
+.year-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.month-chip {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 18px;
+  padding: 0.65rem 0.9rem;
+  background: #f8fbff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  align-items: flex-start;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.month-chip.active {
+  background: #111827;
+  color: #fff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
+}
+
+.month-chip small {
+  color: inherit;
+  opacity: 0.7;
+}
+
+.week-view h3,
+.workweek-view h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.week-strip {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.week-day {
+  flex: 1;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: #f8fafc;
+  padding: 0.75rem 0.35rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.week-day.active {
+  background: #111827;
+  color: #fff;
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.2);
+}
+
+.week-day .dow {
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: inherit;
+  opacity: 0.7;
+}
+
+.week-day strong {
+  font-size: 1.35rem;
+}
+
+.workweek-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.workweek-list article {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 0.7rem 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  background: #f8fafc;
+}
+
+.day-view h3 {
+  margin: 0;
+}
+
+.day-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 240px;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.timeline-row {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.timeline-row .time {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.timeline-row .slot {
+  height: 32px;
+  border-radius: 12px;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.15), transparent);
+  border: 1px dashed rgba(59, 130, 246, 0.4);
+}
+
+@media (max-width: 900px) {
+  #app {
+    padding: 2rem 1rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/usetemporal-vue/demo/tsconfig.json
+++ b/packages/usetemporal-vue/demo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "baseUrl": "./",
+    "paths": {
+      "@allystudio/usetemporal-vue": ["../src"],
+      "@allystudio/usetemporal": ["../../usetemporal/src/index.ts"],
+      "@allystudio/usetemporal/native": ["../../usetemporal/src/native.ts"],
+      "@allystudio/usetemporal/operations": [
+        "../../usetemporal/src/operations.ts"
+      ],
+      "@allystudio/usetemporal/types": ["../../usetemporal/src/types.ts"]
+    }
+  },
+  "include": [
+    "env.d.ts",
+    "src/**/*"
+  ]
+}

--- a/packages/usetemporal-vue/demo/vite.config.ts
+++ b/packages/usetemporal-vue/demo/vite.config.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+const coreSrc = path.resolve(__dirname, "../..", "usetemporal", "src");
+
+const vuePackageSrc = path.resolve(__dirname, "../src");
+const nativeAdapter = path.resolve(coreSrc, "native.ts");
+
+export default defineConfig({
+  root: __dirname,
+  plugins: [vue()],
+  resolve: {
+    alias: [
+      { find: "@allystudio/usetemporal/native", replacement: nativeAdapter },
+      {
+        find: "@allystudio/usetemporal/operations",
+        replacement: path.resolve(coreSrc, "operations.ts"),
+      },
+      {
+        find: "@allystudio/usetemporal/types",
+        replacement: path.resolve(coreSrc, "types.ts"),
+      },
+      {
+        find: "@allystudio/usetemporal",
+        replacement: path.resolve(coreSrc, "index.ts"),
+      },
+      {
+        find: "@allystudio/usetemporal-vue",
+        replacement: vuePackageSrc,
+      },
+    ],
+  },
+  server: {
+    port: 4173,
+    open: true,
+  },
+  build: {
+    outDir: path.resolve(__dirname, "dist"),
+    emptyOutDir: true,
+  },
+});

--- a/packages/usetemporal-vue/package.json
+++ b/packages/usetemporal-vue/package.json
@@ -37,11 +37,14 @@
     "calendar"
   ],
   "scripts": {
+    "pretest": "npm run build --workspace=@allystudio/usetemporal",
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist node_modules"
+    "clean": "rm -rf dist node_modules",
+    "demo": "vite --config demo/vite.config.ts",
+    "demo:build": "vite build --config demo/vite.config.ts"
   },
   "dependencies": {
     "@allystudio/usetemporal": "^2.0.0-alpha.1",
@@ -50,6 +53,7 @@
   "devDependencies": {
     "@types/node": "^22.12.1",
     "@usetemporal/tsconfig": "^2.0.0-alpha.1",
+    "@vitejs/plugin-vue": "^6.0.2",
     "typescript": "^5.7.3",
     "vite": "^7.2.4",
     "vite-plugin-dts": "^4.4.0",

--- a/packages/usetemporal-vue/src/builder.ts
+++ b/packages/usetemporal-vue/src/builder.ts
@@ -17,7 +17,7 @@ import type { TemporalBuilder, VueTemporal } from "./types";
  *
  * @example
  * ```typescript
- * const temporal = useTemporal({ adapter: nativeAdapter, date: new Date() });
+ * const temporal = createTemporal({ adapter: nativeAdapter, date: new Date() });
  * const builder = createTemporalBuilder(temporal);
  *
  * const year = builder.period(new Date(), 'year');
@@ -26,7 +26,30 @@ import type { TemporalBuilder, VueTemporal } from "./types";
  */
 export function createTemporalBuilder(temporal: VueTemporal): TemporalBuilder {
   return {
-    ...temporal,
+    get adapter() {
+      return temporal.adapter;
+    },
+    set adapter(value) {
+      temporal.adapter = value;
+    },
+    get weekStartsOn() {
+      return temporal.weekStartsOn;
+    },
+    set weekStartsOn(value) {
+      temporal.weekStartsOn = value;
+    },
+    get browsing() {
+      return temporal.browsing;
+    },
+    set browsing(value) {
+      temporal.browsing = value;
+    },
+    get now() {
+      return temporal.now;
+    },
+    set now(value) {
+      temporal.now = value;
+    },
 
     period(dateOrOptions: Date | CustomPeriodOptions, unit?: Unit): Period {
       if (typeof dateOrOptions === "object" && "start" in dateOrOptions) {

--- a/packages/usetemporal-vue/src/createTemporal.test.ts
+++ b/packages/usetemporal-vue/src/createTemporal.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { useTemporal, type UseTemporalOptions } from "./useTemporal";
-import { ref, isRef, effect, computed } from "vue";
+import { createTemporal } from "./createTemporal";
+import type { CreateTemporalOptions } from "./types";
+import {
+  ref,
+  isRef,
+  effect,
+  computed,
+} from "vue";
 import { createNativeAdapter } from "@allystudio/usetemporal/native";
 import type { Adapter } from "@allystudio/usetemporal";
 
-describe("useTemporal", () => {
+describe("createTemporal", () => {
   let mockAdapter: Adapter;
   let testDate: Date;
 
@@ -17,9 +23,9 @@ describe("useTemporal", () => {
     it("should throw error when adapter is not provided", () => {
       const options = {
         date: testDate,
-      } as UseTemporalOptions;
+      } as CreateTemporalOptions;
 
-      expect(() => useTemporal(options)).toThrow(
+      expect(() => createTemporal(options)).toThrow(
         "A date adapter is required. Please install and provide an adapter from @allystudio/usetemporal/* packages."
       );
     });
@@ -30,7 +36,7 @@ describe("useTemporal", () => {
         adapter: null as any,
       };
 
-      expect(() => useTemporal(options)).toThrow(
+      expect(() => createTemporal(options)).toThrow(
         "A date adapter is required"
       );
     });
@@ -41,7 +47,7 @@ describe("useTemporal", () => {
         adapter: undefined as any,
       };
 
-      expect(() => useTemporal(options)).toThrow(
+      expect(() => createTemporal(options)).toThrow(
         "A date adapter is required"
       );
     });
@@ -49,7 +55,7 @@ describe("useTemporal", () => {
 
   describe("basic initialization", () => {
     it("should create temporal with required options", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -63,7 +69,7 @@ describe("useTemporal", () => {
 
     it("should accept custom weekStartsOn values", () => {
       for (let day = 0; day <= 6; day++) {
-        const temporal = useTemporal({
+        const temporal = createTemporal({
           date: testDate,
           adapter: mockAdapter,
           weekStartsOn: day,
@@ -74,7 +80,7 @@ describe("useTemporal", () => {
 
     it("should use provided now date", () => {
       const nowDate = new Date(2024, 0, 20, 10, 0, 0);
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
         now: nowDate,
@@ -85,7 +91,7 @@ describe("useTemporal", () => {
 
     it("should default now to current date when not provided", () => {
       const beforeCreate = new Date();
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -100,7 +106,7 @@ describe("useTemporal", () => {
   describe("reactive date handling", () => {
     it("should accept ref date and preserve reactivity", () => {
       const dateRef = ref(testDate);
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: dateRef,
         adapter: mockAdapter,
       });
@@ -114,7 +120,7 @@ describe("useTemporal", () => {
     });
 
     it("should accept plain date and convert to ref", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -125,7 +131,7 @@ describe("useTemporal", () => {
 
     it("should accept ref now and preserve reactivity", () => {
       const nowRef = ref(new Date(2024, 0, 20));
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
         now: nowRef,
@@ -151,7 +157,7 @@ describe("useTemporal", () => {
 
   describe("period initialization", () => {
     it("should initialize browsing period correctly", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -165,7 +171,7 @@ describe("useTemporal", () => {
 
     it("should initialize now period as computed", () => {
       const nowDate = new Date(2024, 0, 20, 15, 30, 45);
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
         now: nowDate,
@@ -181,7 +187,7 @@ describe("useTemporal", () => {
 
   describe("reactivity behavior", () => {
     it("should trigger effects when browsing changes", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -210,7 +216,7 @@ describe("useTemporal", () => {
     });
 
     it("should support computed properties based on temporal state", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -234,7 +240,7 @@ describe("useTemporal", () => {
     });
 
     it("should cleanup reactive effects properly", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -280,7 +286,7 @@ describe("useTemporal", () => {
       const dateRef = ref(testDate);
       const nowRef = ref(new Date(2024, 0, 20));
 
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: dateRef,
         adapter: mockAdapter,
         now: nowRef,
@@ -316,7 +322,7 @@ describe("useTemporal", () => {
   describe("edge cases", () => {
     it("should handle dates at year boundaries", () => {
       const endOfYear = new Date(2023, 11, 31, 23, 59, 59);
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: endOfYear,
         adapter: mockAdapter,
       });
@@ -326,7 +332,7 @@ describe("useTemporal", () => {
 
     it("should handle leap year dates", () => {
       const leapDay = new Date(2024, 1, 29); // Feb 29, 2024
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: leapDay,
         adapter: mockAdapter,
       });
@@ -335,7 +341,7 @@ describe("useTemporal", () => {
     });
 
     it("should handle invalid weekStartsOn gracefully", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
         weekStartsOn: -1 as any,
@@ -345,7 +351,7 @@ describe("useTemporal", () => {
     });
 
     it("should handle weekStartsOn as undefined", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
         weekStartsOn: undefined,
@@ -365,7 +371,7 @@ describe("useTemporal", () => {
         diff: vi.fn(),
       };
 
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: customAdapter,
       });
@@ -374,7 +380,7 @@ describe("useTemporal", () => {
     });
 
     it("should preserve adapter reference", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter: mockAdapter,
       });
@@ -382,14 +388,37 @@ describe("useTemporal", () => {
       expect(temporal.adapter).toBe(mockAdapter);
       expect(temporal.adapter.startOf).toBe(mockAdapter.startOf);
     });
+
+    it("should recompute week periods when adapter weekStartsOn changes", () => {
+      const date = new Date(2024, 0, 3, 12); // Wednesday
+      const mondayAdapter = createNativeAdapter({ weekStartsOn: 1 });
+      const sundayAdapter = createNativeAdapter({ weekStartsOn: 0 });
+
+      const temporal = createTemporal({
+        date,
+        adapter: mondayAdapter,
+      });
+
+      const mondayWeek = temporal.period(date, "week");
+      expect(mondayWeek.start.getDay()).toBe(1);
+      expect(mondayWeek.start.getDate()).toBe(1);
+
+      temporal.adapter = sundayAdapter;
+
+      const sundayWeek = temporal.period(date, "week");
+      expect(sundayWeek.start.getDay()).toBe(0);
+      expect(sundayWeek.start.getDate()).toBe(31);
+      expect(sundayWeek.start.getMonth()).toBe(11); // Dec 31, 2023
+    });
   });
+
 
   describe("performance", () => {
     it("should execute in less than 100ms", () => {
       const start = performance.now();
 
       for (let i = 0; i < 100; i++) {
-        useTemporal({
+        createTemporal({
           date: new Date(),
           adapter: mockAdapter,
         });
@@ -410,7 +439,7 @@ describe("useTemporal", () => {
 
       it(`should assign browsing period for ${label}`, () => {
         const baseDate = new Date(Date.UTC(2024, 0, 1));
-        const temporal = useTemporal({
+        const temporal = createTemporal({
           date: baseDate,
           adapter: createNativeAdapter(),
         });

--- a/packages/usetemporal-vue/src/createTemporal.ts
+++ b/packages/usetemporal-vue/src/createTemporal.ts
@@ -1,0 +1,70 @@
+import { computed, getCurrentInstance, isRef, ref } from "vue";
+import type { Period } from "@allystudio/usetemporal";
+import { createTemporalBuilder } from "./builder";
+import type { TemporalBuilder, CreateTemporalOptions, VueTemporal } from "./types";
+import { provideTemporal } from "./temporalContext";
+
+/**
+ * Creates a temporal instance with builder methods (Level 2 API)
+ *
+ * Returns a temporal builder that provides convenience methods
+ * wrapping pure operations. Methods automatically pass the adapter.
+ *
+ * @param options - Configuration options
+ * @returns A temporal builder with convenience methods
+ *
+ * @example
+ * ```typescript
+ * const temporal = createTemporal({
+ *   adapter: nativeAdapter,
+ *   date: new Date()
+ * });
+ *
+ * const year = temporal.period(new Date(), "year");
+ * const months = temporal.divide(year, "month");
+ * ```
+ */
+export function createTemporal(options: CreateTemporalOptions): TemporalBuilder {
+  if (!options.adapter) {
+    throw new Error(
+      "A date adapter is required. Please install and provide an adapter from @allystudio/usetemporal/* packages."
+    );
+  }
+
+  const browsingDate = isRef(options.date) ? options.date : ref(options.date);
+  const nowDate = isRef(options.now)
+    ? options.now
+    : ref(options.now ?? new Date());
+
+  // Create a reactive Period for browsing that represents a point in time
+  const browsing = ref<Period>({
+    start: browsingDate.value,
+    end: browsingDate.value,
+    type: "day", // Default browsing unit is day
+    date: browsingDate.value,
+  });
+
+  // Create a reactive Period for now that represents a point in time
+  const now = computed(() => {
+    const nowValue = nowDate.value;
+    return {
+      start: nowValue,
+      end: nowValue,
+      type: "second" as const, // Most precise unit for a point in time
+      date: nowValue,
+    };
+  });
+
+  const temporal: VueTemporal = {
+    adapter: options.adapter,
+    weekStartsOn: options.weekStartsOn ?? 1, // Default to Monday
+    browsing,
+    now,
+  };
+
+  const builder = createTemporalBuilder(temporal);
+  if (getCurrentInstance()) {
+    provideTemporal(builder);
+  }
+  return builder;
+}

--- a/packages/usetemporal-vue/src/index.ts
+++ b/packages/usetemporal-vue/src/index.ts
@@ -1,7 +1,12 @@
+export { createTemporal } from "./createTemporal";
 export { useTemporal } from "./useTemporal";
 export { usePeriod } from "./usePeriod";
 export { createTemporalBuilder } from "./builder";
-export type { VueTemporal, UseTemporalOptions, TemporalBuilder } from "./types";
+export type {
+  VueTemporal,
+  CreateTemporalOptions,
+  TemporalBuilder,
+} from "./types";
 
 export {
   period,

--- a/packages/usetemporal-vue/src/reactivity.test.ts
+++ b/packages/usetemporal-vue/src/reactivity.test.ts
@@ -3,7 +3,7 @@ import { ref, computed, effect, isRef, reactive } from "vue";
 import { createNativeAdapter } from "@allystudio/usetemporal/native";
 import { divide, go, next } from "@allystudio/usetemporal/operations";
 import type { Adapter, Period } from "@allystudio/usetemporal";
-import { useTemporal } from "./useTemporal";
+import { createTemporal } from "./createTemporal";
 import { usePeriod } from "./usePeriod";
 
 describe("Vue Reactivity Integration", () => {
@@ -17,7 +17,7 @@ describe("Vue Reactivity Integration", () => {
 
   describe("Temporal reactivity", () => {
     it("should update browsing period reactively", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -45,7 +45,7 @@ describe("Vue Reactivity Integration", () => {
     it("should handle reactive now updates", () => {
       const nowRef = ref(new Date(2024, 0, 1, 12, 0, 0));
       
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
         now: nowRef,
@@ -70,7 +70,7 @@ describe("Vue Reactivity Integration", () => {
     });
 
     it("should support computed properties based on temporal state", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -99,7 +99,7 @@ describe("Vue Reactivity Integration", () => {
 
   describe("usePeriod composable reactivity", () => {
     it("should create reactive period from temporal", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -127,7 +127,7 @@ describe("Vue Reactivity Integration", () => {
     });
 
     it("should support multiple reactive periods", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -158,7 +158,7 @@ describe("Vue Reactivity Integration", () => {
 
   describe("Complex reactive workflows", () => {
     it("should handle calendar drill-down reactively", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -192,7 +192,7 @@ describe("Vue Reactivity Integration", () => {
     });
 
     it("should handle reactive period selection", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -226,7 +226,7 @@ describe("Vue Reactivity Integration", () => {
     });
 
     it("should clean up effects properly", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -260,7 +260,7 @@ describe("Vue Reactivity Integration", () => {
 
     it("should handle concurrent reactive updates efficiently", () => {
       const dateRef = ref(testDate);
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: dateRef,
         adapter,
       });
@@ -315,7 +315,7 @@ describe("Vue Reactivity Integration", () => {
 
   describe("Reactive state management patterns", () => {
     it("should support reactive calendar state", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -360,7 +360,7 @@ describe("Vue Reactivity Integration", () => {
     });
 
     it("should handle reactive period highlighting", () => {
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });
@@ -390,7 +390,7 @@ describe("Vue Reactivity Integration", () => {
     it("all reactive tests should complete in under 100ms", () => {
       const start = performance.now();
       
-      const temporal = useTemporal({
+      const temporal = createTemporal({
         date: testDate,
         adapter,
       });

--- a/packages/usetemporal-vue/src/temporalContext.ts
+++ b/packages/usetemporal-vue/src/temporalContext.ts
@@ -1,0 +1,18 @@
+import { inject, provide } from "vue";
+import type { TemporalBuilder } from "./types";
+
+const TEMPORAL_CONTEXT_KEY = Symbol("TemporalContext");
+
+export function provideTemporal(builder: TemporalBuilder) {
+  provide(TEMPORAL_CONTEXT_KEY, builder);
+}
+
+export function injectTemporal(): TemporalBuilder {
+  const temporal = inject<TemporalBuilder | null>(TEMPORAL_CONTEXT_KEY, null);
+  if (!temporal) {
+    throw new Error(
+      "No temporal instance provided. Call createTemporal() in an ancestor component before using useTemporal()."
+    );
+  }
+  return temporal;
+}

--- a/packages/usetemporal-vue/src/types.ts
+++ b/packages/usetemporal-vue/src/types.ts
@@ -17,7 +17,7 @@ export interface VueTemporal {
  * Options for creating a Vue temporal instance.
  * Accepts native dates or refs so state can be controlled externally.
  */
-export interface UseTemporalOptions {
+export interface CreateTemporalOptions {
   date: Date | Ref<Date>;
   now?: Date | Ref<Date>;
   adapter: Adapter;

--- a/packages/usetemporal-vue/src/useTemporal.inject.test.ts
+++ b/packages/usetemporal-vue/src/useTemporal.inject.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { TemporalBuilder } from "./types";
+import { createTemporal } from "./createTemporal";
+import { useTemporal } from "./useTemporal";
+import { createNativeAdapter } from "@allystudio/usetemporal/native";
+
+type VueModule = typeof import("vue");
+
+const context = new Map<symbol, TemporalBuilder>();
+let hasInstance = false;
+
+vi.mock("vue", async () => {
+  const actual = (await vi.importActual<VueModule>("vue")) as VueModule;
+  return {
+    ...actual,
+    getCurrentInstance: () => (hasInstance ? ({}) : null),
+    provide: (key: symbol, value: TemporalBuilder) => {
+      context.set(key, value);
+    },
+    inject: (key: symbol) => context.get(key),
+  };
+});
+
+describe("useTemporal injector", () => {
+  const adapter = createNativeAdapter();
+
+beforeEach(() => {
+  context.clear();
+  hasInstance = false;
+});
+
+  it("injects the nearest provided temporal instance", () => {
+    hasInstance = true;
+    const provided = createTemporal({
+      date: new Date(2024, 0, 1),
+      adapter,
+    });
+    const injected = useTemporal();
+    expect(injected).toBe(provided);
+  });
+
+  it("throws a helpful error when no provider exists", () => {
+    context.clear();
+    expect(() => useTemporal()).toThrow("No temporal instance provided");
+  });
+});

--- a/packages/usetemporal-vue/src/useTemporal.ts
+++ b/packages/usetemporal-vue/src/useTemporal.ts
@@ -1,65 +1,17 @@
-import { computed, isRef, ref } from "vue";
-import type { Period } from "@allystudio/usetemporal";
-import { createTemporalBuilder } from "./builder";
-import type { TemporalBuilder, UseTemporalOptions, VueTemporal } from "./types";
+import type { TemporalBuilder } from "./types";
+import { injectTemporal } from "./temporalContext";
 
 /**
- * Creates a temporal instance with builder methods (Level 2 API)
+ * Injects the nearest temporal instance provided via createTemporal().
  *
- * Returns a temporal builder that provides convenience methods
- * wrapping pure operations. Methods automatically pass the adapter.
- *
- * @param options - Configuration options
- * @returns A temporal builder with convenience methods
+ * @returns The current TemporalBuilder from context
  *
  * @example
- * ```typescript
- * const temporal = useTemporal({
- *   adapter: nativeAdapter,
- *   date: new Date()
- * });
- *
- * const year = temporal.period(new Date(), "year");
- * const months = temporal.divide(year, "month");
+ * ```ts
+ * const temporal = useTemporal();
+ * const month = temporal.period(new Date(), "month");
  * ```
  */
-export function useTemporal(options: UseTemporalOptions): TemporalBuilder {
-  if (!options.adapter) {
-    throw new Error(
-      "A date adapter is required. Please install and provide an adapter from @allystudio/usetemporal/* packages."
-    );
-  }
-
-  const browsingDate = isRef(options.date) ? options.date : ref(options.date);
-  const nowDate = isRef(options.now)
-    ? options.now
-    : ref(options.now ?? new Date());
-
-  // Create a reactive Period for browsing that represents a point in time
-  const browsing = ref<Period>({
-    start: browsingDate.value,
-    end: browsingDate.value,
-    type: "day", // Default browsing unit is day
-    date: browsingDate.value,
-  });
-
-  // Create a reactive Period for now that represents a point in time
-  const now = computed(() => {
-    const nowValue = nowDate.value;
-    return {
-      start: nowValue,
-      end: nowValue,
-      type: "second" as const, // Most precise unit for a point in time
-      date: nowValue,
-    };
-  });
-
-  const temporal: VueTemporal = {
-    adapter: options.adapter,
-    weekStartsOn: options.weekStartsOn ?? 1, // Default to Monday
-    browsing,
-    now,
-  };
-
-  return createTemporalBuilder(temporal);
+export function useTemporal(): TemporalBuilder {
+  return injectTemporal();
 }

--- a/packages/usetemporal-vue/vitest.config.ts
+++ b/packages/usetemporal-vue/vitest.config.ts
@@ -1,11 +1,28 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 import viteConfig from "./vite.config";
 
+const coreRoot = resolve(__dirname, "../usetemporal/src");
+const alias = {
+  "@allystudio/usetemporal": resolve(coreRoot, "index.ts"),
+  "@allystudio/usetemporal/native": resolve(coreRoot, "native.ts"),
+  "@allystudio/usetemporal/types": resolve(coreRoot, "types.ts"),
+  "@allystudio/usetemporal/temporal": resolve(coreRoot, "temporal.ts"),
+  "@allystudio/usetemporal/operations": resolve(coreRoot, "operations.ts"),
+};
+
 export default defineConfig({
   ...viteConfig,
+  resolve: {
+    ...(viteConfig.resolve ?? {}),
+    alias: {
+      ...(viteConfig.resolve?.alias ?? {}),
+      ...alias,
+    },
+  },
   test: {
     ...viteConfig.test,
     globals: false,
-    include: ["src/**/*.test.ts"]
-  }
+    include: ["src/**/*.test.ts"],
+  },
 });


### PR DESCRIPTION
- add createTemporal factory that auto-provides the builder and migrate docs/tests
- keep useTemporal as the injector to access the shared instance
- add a demo playground plus tooling updates to develop the Vue integration