### PR TITLE
Add reusable calendar views

### DIFF
--- a/vitepress/.vitepress/config.ts
+++ b/vitepress/.vitepress/config.ts
@@ -299,6 +299,10 @@ export default defineConfig({
           __dirname,
           "../../packages/usetemporal/src/native.ts"
         ),
+        "@allystudio/usetemporal/calendar": path.resolve(
+          __dirname,
+          "../../packages/usetemporal/src/calendar/index.ts"
+        ),
       },
     },
   },

--- a/vitepress/.vitepress/theme/components/MonthGrid.vue
+++ b/vitepress/.vitepress/theme/components/MonthGrid.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import type { Period } from "@allystudio/usetemporal";
+import type { Ref } from "vue";
+import { computed, unref } from "vue";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+import { createStableMonth } from "../../../../packages/usetemporal/src/calendar";
+import WeekNamesView from "./WeekNamesView.vue";
+
+const props = withDefaults(
+  defineProps<{
+    month: Period | Ref<Period>;
+    selectedDay?: Period | Ref<Period | null> | null;
+    interactive?: boolean;
+    density?: "default" | "compact";
+  }>(),
+  {
+    interactive: true,
+    density: "default",
+  }
+);
+
+const emit = defineEmits<{
+  select: [day: Period];
+}>();
+
+const temporal = useTemporal();
+
+const targetMonth = computed(() => unref(props.month));
+const selectedDay = computed<Period | null>(() => {
+  const value = props.selectedDay;
+  const resolved = value ? unref(value) : null;
+  return resolved ?? null;
+});
+
+const stableMonth = computed(() =>
+  createStableMonth(
+    temporal.adapter,
+    temporal.weekStartsOn ?? 0,
+    targetMonth.value.date
+  )
+);
+
+const days = computed(() => temporal.divide(stableMonth.value, "day"));
+
+const dayCells = computed(() =>
+  days.value.map((period) => ({
+    period,
+    isCurrentMonth: temporal.contains(targetMonth.value, period.date),
+    isSelected:
+      selectedDay.value !== null &&
+      temporal.isSame(period, selectedDay.value, "day"),
+    isToday: temporal.isSame(period, temporal.now.value, "day"),
+  }))
+);
+
+function handleSelect(day: Period) {
+  if (!props.interactive) return;
+  emit("select", day);
+}
+</script>
+
+<template>
+  <div class="month-grid" :class="[`density-${density}`]">
+    <WeekNamesView class="month-grid-weeknames" />
+    <div class="month-grid-days">
+      <button
+        v-for="cell in dayCells"
+        :key="cell.period.start.toISOString()"
+        type="button"
+        class="month-grid-day"
+        :class="{
+          'is-other-month': !cell.isCurrentMonth,
+          'is-selected': cell.isSelected,
+          'is-today': cell.isToday,
+          'is-static': !interactive,
+        }"
+        :disabled="!interactive"
+        @click="handleSelect(cell.period)"
+      >
+        {{ cell.period.date.getDate() }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.month-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.month-grid-weeknames {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  text-align: center;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-2);
+}
+
+.month-grid-days {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.month-grid-day {
+  height: 3rem;
+  border-radius: 10px;
+  border: none;
+  background: var(--vp-c-bg-mute);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.month-grid-day.is-other-month {
+  color: var(--vp-c-text-3);
+  background: transparent;
+}
+
+.month-grid-day.is-selected {
+  background: var(--vp-c-brand);
+  color: var(--vp-c-bg);
+  box-shadow: 0 0 0 1px var(--vp-c-brand);
+}
+
+.month-grid-day.is-today {
+  box-shadow: 0 0 0 1px var(--vp-c-brand);
+}
+
+.month-grid-day.is-static {
+  cursor: default;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.month-grid.density-compact {
+  gap: 0.25rem;
+}
+
+.month-grid.density-compact .month-grid-weeknames {
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+}
+
+.month-grid.density-compact .month-grid-days {
+  gap: 0.2rem;
+}
+
+.month-grid.density-compact .month-grid-day {
+  height: 1.6rem;
+  font-size: 0.7rem;
+  border-radius: 6px;
+}
+</style>

--- a/vitepress/.vitepress/theme/components/MonthName.vue
+++ b/vitepress/.vitepress/theme/components/MonthName.vue
@@ -1,15 +1,26 @@
 <script setup lang="ts">
+import type { Period } from "@allystudio/usetemporal";
+import type { Ref } from "vue";
+import { computed, unref } from "vue";
 import { useTemporal, usePeriod } from "@allystudio/usetemporal-vue";
+
+const props = defineProps<{
+  period?: Period | Ref<Period>;
+}>();
 
 const temporal = useTemporal();
 const month = usePeriod(temporal, "month");
 
 const formatter = new Intl.DateTimeFormat(temporal.locale, { month: "long" });
 
+const targetMonth = computed(() => {
+  const provided = props.period;
+  return provided ? unref(provided) : month.value;
+});
 </script>
 
 <template>
   <span class="temporal-month-name">
-    {{ formatter.format(month.start) }}
+    {{ formatter.format(targetMonth.start) }}
   </span>
 </template>

--- a/vitepress/.vitepress/theme/components/WeekNamesView.vue
+++ b/vitepress/.vitepress/theme/components/WeekNamesView.vue
@@ -17,3 +17,15 @@ const formatter = new Intl.DateTimeFormat(temporal.locale, { weekday: "short" })
     </span>
   </div>
 </template>
+
+<style scoped>
+.week-names-view {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  text-align: center;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/vitepress/.vitepress/theme/components/WeekView.vue
+++ b/vitepress/.vitepress/theme/components/WeekView.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+import type { Period } from "@allystudio/usetemporal";
+import type { Ref } from "vue";
+import { computed, unref } from "vue";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+import WeekNamesView from "./WeekNamesView.vue";
+
+const HOURS = Array.from({ length: 24 }, (_, index) => index);
+
+const props = defineProps<{
+  week: Period | Ref<Period>;
+}>();
+
+const temporal = useTemporal();
+const targetWeek = computed(() => unref(props.week));
+const days = computed(() => temporal.divide(targetWeek.value, "day"));
+const hourFormatter = computed(
+  () =>
+    new Intl.DateTimeFormat(temporal.locale ?? "en", {
+      hour: "numeric",
+    })
+);
+
+const dayColumns = computed(() =>
+  days.value.map((period) => ({
+    period,
+    isToday: temporal.isSame(period, temporal.now.value, "day"),
+  }))
+);
+
+const hourLabels = computed(() =>
+  HOURS.map((hour) => ({
+    hour,
+    label: hourFormatter.value.format(new Date(1970, 0, 1, hour)),
+  }))
+);
+</script>
+
+<template>
+  <section class="week-view">
+    <div class="week-view-header">
+      <div class="week-view-hour-spacer"></div>
+      <WeekNamesView class="week-view-names" />
+    </div>
+    <div class="week-view-body">
+      <div class="week-view-hours">
+        <div v-for="hour in hourLabels" :key="hour.hour" class="week-view-hour">
+          {{ hour.label }}
+        </div>
+      </div>
+      <div class="week-view-days">
+        <div
+          v-for="day in dayColumns"
+          :key="day.period.start.toISOString()"
+          class="week-view-day-column"
+          :class="{ 'is-today': day.isToday }"
+        >
+          <div
+            v-for="hour in hourLabels"
+            :key="`${day.period.start.toISOString()}-${hour.hour}`"
+            class="week-view-slot"
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.week-view {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.week-view-header {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  align-items: center;
+}
+
+.week-view-hour-spacer {
+  height: 1px;
+}
+
+.week-view-names {
+  margin-left: 0.2rem;
+}
+
+.week-view-body {
+  display: flex;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.week-view-hours {
+  flex: 0 0 70px;
+  background: var(--vp-c-bg-soft);
+  border-right: 1px solid var(--vp-c-border);
+  display: flex;
+  flex-direction: column;
+}
+
+.week-view-hour {
+  flex: 1;
+  font-size: 0.75rem;
+  color: var(--vp-c-text-2);
+  padding: 0.25rem 0.4rem;
+  border-top: 1px solid var(--vp-c-border-soft);
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+}
+
+.week-view-hour:first-child {
+  border-top: 0;
+}
+
+.week-view-days {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  flex: 1;
+}
+
+.week-view-day-column {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--vp-c-border);
+}
+
+.week-view-day-column:last-child {
+  border-right: 0;
+}
+
+.week-view-day-column.is-today {
+  background: color-mix(in srgb, var(--vp-c-brand) 8%, transparent);
+}
+
+.week-view-slot {
+  flex: 1;
+  border-top: 1px solid var(--vp-c-border-soft);
+}
+
+.week-view-slot:first-child {
+  border-top: 0;
+}
+
+@media (max-width: 960px) {
+  .week-view-day-header {
+    font-size: 0.75rem;
+  }
+
+  .week-view-hour {
+    font-size: 0.65rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .week-view {
+    gap: 0.25rem;
+  }
+
+  .week-view-header {
+    grid-template-columns: 50px repeat(7, minmax(0, 1fr));
+  }
+
+  .week-view-hours {
+    flex-basis: 50px;
+  }
+}
+</style>

--- a/vitepress/.vitepress/theme/components/YearView.vue
+++ b/vitepress/.vitepress/theme/components/YearView.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import type { Period } from "@allystudio/usetemporal";
+import { computed } from "vue";
+import { useTemporal } from "@allystudio/usetemporal-vue";
+import MonthName from "./MonthName.vue";
+import MonthGrid from "./MonthGrid.vue";
+
+const props = defineProps<{
+  year: Period;
+}>();
+
+const temporal = useTemporal();
+const months = computed(() => temporal.divide(props.year, "month"));
+</script>
+
+<template>
+  <section class="year-view">
+    <div class="year-view-grid">
+      <article
+        v-for="month in months"
+        :key="month.start.toISOString()"
+        class="year-view-month"
+      >
+        <header class="year-view-month-header">
+          <MonthName :period="month" />
+        </header>
+        <MonthGrid :month="month" :interactive="false" density="compact" :selected-day="null" />
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.year-view {
+  width: 100%;
+}
+
+.year-view-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.year-view-month {
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.year-view-month-header {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 960px) {
+  .year-view-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .year-view-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/vitepress/.vitepress/theme/styles/custom.css
+++ b/vitepress/.vitepress/theme/styles/custom.css
@@ -107,59 +107,6 @@
   margin: 0;
 }
 
-.vue-temporal-demo .week-names-view {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  text-align: center;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--vp-c-text-2);
-  margin-bottom: 0.4rem;
-}
-
-.vue-temporal-demo .calendar-grid {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 0.35rem;
-}
-
-.vue-temporal-demo .weekday-label {
-  text-align: center;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--vp-c-text-2);
-}
-
-.vue-temporal-demo .day-cell {
-  height: 3.25rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  background: var(--vp-c-bg-mute);
-}
-
-.vue-temporal-demo .day-cell[data-column-start] {
-  grid-column-start: attr(data-column-start number);
-}
-
-.vue-temporal-demo .day-cell.is-other-month {
-  opacity: 0.35;
-}
-
-.vue-temporal-demo .day-cell.is-selected {
-  background: var(--vp-c-brand);
-  color: var(--vp-c-bg);
-  border-color: transparent;
-}
-
-.vue-temporal-demo .day-cell.is-today {
-  border-color: var(--vp-c-brand);
-}
-
 .vue-temporal-demo .demo-actions {
   display: flex;
   gap: 0.5rem;

--- a/vitepress/tsconfig.json
+++ b/vitepress/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@allystudio/usetemporal-vue": ["../packages/usetemporal-vue/src"],
-      "@allystudio/usetemporal/native": ["../packages/usetemporal/src/native.ts"]
+      "@allystudio/usetemporal/native": ["../packages/usetemporal/src/native.ts"],
+      "@allystudio/usetemporal/calendar": ["../packages/usetemporal/src/calendar/index.ts"]
     },
     "types": ["vitepress/client"]
   },


### PR DESCRIPTION
Adds MonthGrid, WeekView, and YearView so the docs demo can switch between week, month, and year layouts while keeping styles scoped. MonthGrid renders a stable 6-week calendar via createStableMonth and powers both the main month view and the year grid. WeekView mimics Google Calendar with hourly columns and reuses WeekNamesView.