### PR TITLE
ci: add PR workflow — tests, build, lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tz: [UTC, Europe/Zurich, America/New_York, Asia/Tokyo]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - run: npm test
+        env:
+          TZ: ${{ matrix.tz }}
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - run: npm run build --workspaces --if-present
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - run: npm run lint:workspaces
+
+      - run: npx prettier --check .


### PR DESCRIPTION
## Summary
- Tests run in 4 timezones (UTC, Zurich, New York, Tokyo) on every PR
- Build verification for all packages
- Lint + prettier check

## Test plan
- CI workflow triggers on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)