### PR TITLE
fix: export gap() from package root

### DIFF
--- a/packages/minuta/src/index.ts
+++ b/packages/minuta/src/index.ts
@@ -10,6 +10,7 @@ export {
   split,
   merge,
   isSame,
+  gap,
 } from "./operations";
 
 // Types


### PR DESCRIPTION
## Summary
- Adds `gap` to the root export in `packages/minuta/src/index.ts`
- Was the only operation missing from `import { gap } from 'minuta'`

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)