### PR TITLE
feat: add duration(), clamp(), resize() operations

### DIFF
--- a/packages/minuta/src/__tests__/integration/exports.test.ts
+++ b/packages/minuta/src/__tests__/integration/exports.test.ts
@@ -20,15 +20,18 @@ describe("Export Verification Tests", () => {
 
     it("should export all expected operation functions", () => {
       const expectedOperations = [
+        "clamp",
         "contains",
         "derivePeriod",
         "createPeriod",
         "divide",
+        "duration",
         "go",
         "isSame",
         "merge",
         "next",
         "previous",
+        "resize",
         "split",
       ];
 
@@ -54,6 +57,10 @@ describe("Export Verification Tests", () => {
         "split",
         "merge",
         "isSame",
+        "gap",
+        "clamp",
+        "duration",
+        "resize",
       ];
 
       expectedOperations.forEach((op) => {
@@ -126,6 +133,10 @@ describe("Export Verification Tests", () => {
         "split",
         "merge",
         "isSame",
+        "gap",
+        "clamp",
+        "duration",
+        "resize",
       ];
 
       operationNames.forEach((op) => {

--- a/packages/minuta/src/index.ts
+++ b/packages/minuta/src/index.ts
@@ -1,16 +1,19 @@
 // Operations - pure functions
 export {
+  clamp,
+  contains,
+  createPeriod,
+  derivePeriod,
   divide,
+  duration,
+  gap,
+  go,
+  isSame,
+  merge,
   next,
   previous,
-  go,
-  contains,
-  derivePeriod,
-  createPeriod,
+  resize,
   split,
-  merge,
-  isSame,
-  gap,
 } from "./operations";
 
 // Types

--- a/packages/minuta/src/operations.ts
+++ b/packages/minuta/src/operations.ts
@@ -7,7 +7,9 @@
  * Tree-shakable - only import what you need.
  */
 export {
+  clamp,
   contains,
+  duration,
   gap,
   divide,
   go,
@@ -17,5 +19,6 @@ export {
   derivePeriod,
   createPeriod,
   previous,
+  resize,
   split,
 } from "./operations/index";

--- a/packages/minuta/src/operations/clamp.test.ts
+++ b/packages/minuta/src/operations/clamp.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { clamp } from "./clamp";
+import { createPeriod } from "./period";
+
+describe("clamp", () => {
+  const bounds = createPeriod(new Date(2024, 0, 10), new Date(2024, 0, 20));
+
+  it("truncates period that extends past bounds", () => {
+    const wide = createPeriod(new Date(2024, 0, 5), new Date(2024, 0, 25));
+    const result = clamp(wide, bounds)!;
+    expect(result.start).toEqual(new Date(2024, 0, 10));
+    expect(result.end).toEqual(new Date(2024, 0, 20));
+  });
+
+  it("returns as-is when fully within bounds", () => {
+    const inner = createPeriod(new Date(2024, 0, 12), new Date(2024, 0, 18));
+    const result = clamp(inner, bounds)!;
+    expect(result.start).toEqual(new Date(2024, 0, 12));
+    expect(result.end).toEqual(new Date(2024, 0, 18));
+  });
+
+  it("truncates start only", () => {
+    const earlyStart = createPeriod(
+      new Date(2024, 0, 5),
+      new Date(2024, 0, 15)
+    );
+    const result = clamp(earlyStart, bounds)!;
+    expect(result.start).toEqual(new Date(2024, 0, 10));
+    expect(result.end).toEqual(new Date(2024, 0, 15));
+  });
+
+  it("truncates end only", () => {
+    const lateEnd = createPeriod(new Date(2024, 0, 15), new Date(2024, 0, 25));
+    const result = clamp(lateEnd, bounds)!;
+    expect(result.start).toEqual(new Date(2024, 0, 15));
+    expect(result.end).toEqual(new Date(2024, 0, 20));
+  });
+
+  it("returns null when entirely outside bounds", () => {
+    const before = createPeriod(new Date(2024, 0, 1), new Date(2024, 0, 5));
+    expect(clamp(before, bounds)).toBeNull();
+
+    const after = createPeriod(new Date(2024, 0, 25), new Date(2024, 0, 30));
+    expect(clamp(after, bounds)).toBeNull();
+  });
+
+  it("returns type custom", () => {
+    const inner = createPeriod(new Date(2024, 0, 12), new Date(2024, 0, 18));
+    expect(clamp(inner, bounds)!.type).toBe("custom");
+  });
+});

--- a/packages/minuta/src/operations/clamp.ts
+++ b/packages/minuta/src/operations/clamp.ts
@@ -1,0 +1,24 @@
+import type { TimePeriod } from "../types";
+
+/**
+ * Constrain a period to fit within bounds.
+ *
+ * Returns null if the period is entirely outside bounds.
+ *
+ * @example
+ * const selection = createPeriod(new Date(2026, 0, 5), new Date(2026, 0, 25))
+ * const allowed = createPeriod(new Date(2026, 0, 10), new Date(2026, 0, 20))
+ * clamp(selection, allowed)
+ * // → { start: Jan 10, end: Jan 20, type: "custom" }
+ */
+export function clamp(
+  period: TimePeriod,
+  bounds: TimePeriod
+): TimePeriod | null {
+  const start = Math.max(period.start.getTime(), bounds.start.getTime());
+  const end = Math.min(period.end.getTime(), bounds.end.getTime());
+
+  if (start > end) return null;
+
+  return { start: new Date(start), end: new Date(end), type: "custom" };
+}

--- a/packages/minuta/src/operations/duration.test.ts
+++ b/packages/minuta/src/operations/duration.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { duration } from "./duration";
+import { createPeriod } from "./period";
+
+describe("duration", () => {
+  const oneHour = createPeriod(
+    new Date(2024, 0, 1, 9, 0),
+    new Date(2024, 0, 1, 10, 0)
+  );
+
+  const ninetyMinutes = createPeriod(
+    new Date(2024, 0, 1, 9, 0),
+    new Date(2024, 0, 1, 10, 30)
+  );
+
+  const threeDays = createPeriod(
+    new Date(2024, 0, 1),
+    new Date(2024, 0, 3, 23, 59, 59, 999)
+  );
+
+  it("returns milliseconds when no unit given", () => {
+    expect(duration(oneHour)).toBe(3_600_000);
+  });
+
+  it("returns complete hours", () => {
+    expect(duration(oneHour, "hour")).toBe(1);
+    expect(duration(ninetyMinutes, "hour")).toBe(1); // truncates
+  });
+
+  it("returns complete minutes", () => {
+    expect(duration(ninetyMinutes, "minute")).toBe(90);
+  });
+
+  it("returns complete seconds", () => {
+    expect(duration(oneHour, "second")).toBe(3600);
+  });
+
+  it("returns complete days", () => {
+    expect(duration(threeDays, "day")).toBe(2); // 2.999... truncates to 2
+  });
+
+  it("returns 0 for zero-width period", () => {
+    const point = createPeriod(new Date(2024, 0, 1), new Date(2024, 0, 1));
+    expect(duration(point)).toBe(0);
+    expect(duration(point, "hour")).toBe(0);
+  });
+});

--- a/packages/minuta/src/operations/duration.ts
+++ b/packages/minuta/src/operations/duration.ts
@@ -1,0 +1,31 @@
+import type { Period } from "../types";
+
+/**
+ * Get the duration of a period in milliseconds, or in complete units.
+ *
+ * @example
+ * duration(meeting)            // 5400000 (ms)
+ * duration(meeting, 'hour')    // 1 (complete hours)
+ * duration(meeting, 'minute')  // 90
+ */
+export function duration(period: Period): number;
+export function duration(period: Period, unit: "hour"): number;
+export function duration(period: Period, unit: "minute"): number;
+export function duration(period: Period, unit: "second"): number;
+export function duration(period: Period, unit: "day"): number;
+export function duration(
+  period: Period,
+  unit?: "day" | "hour" | "minute" | "second"
+): number {
+  const ms = period.end.getTime() - period.start.getTime();
+  if (!unit) return ms;
+
+  const divisors = {
+    day: 86_400_000,
+    hour: 3_600_000,
+    minute: 60_000,
+    second: 1_000,
+  };
+
+  return Math.trunc(ms / divisors[unit]);
+}

--- a/packages/minuta/src/operations/index.ts
+++ b/packages/minuta/src/operations/index.ts
@@ -1,5 +1,7 @@
+export { clamp } from "./clamp";
 export { contains } from "./contains";
 export { derivePeriod, createPeriod } from "./period";
+export { duration } from "./duration";
 export { gap } from "./gap";
 export { divide } from "./divide";
 export { go } from "./go";
@@ -7,4 +9,5 @@ export { isSame } from "./isSame";
 export { merge } from "./merge";
 export { next } from "./next";
 export { previous } from "./previous";
+export { resize } from "./resize";
 export { split } from "./split";

--- a/packages/minuta/src/operations/resize.test.ts
+++ b/packages/minuta/src/operations/resize.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { resize } from "./resize";
+import { createPeriod } from "./period";
+
+describe("resize", () => {
+  const meeting = createPeriod(
+    new Date(2024, 0, 1, 9, 0),
+    new Date(2024, 0, 1, 10, 0)
+  );
+
+  it("extends end", () => {
+    const result = resize(meeting, "end", new Date(2024, 0, 1, 11, 30))!;
+    expect(result.start).toEqual(new Date(2024, 0, 1, 9, 0));
+    expect(result.end).toEqual(new Date(2024, 0, 1, 11, 30));
+  });
+
+  it("moves start earlier", () => {
+    const result = resize(meeting, "start", new Date(2024, 0, 1, 8, 0))!;
+    expect(result.start).toEqual(new Date(2024, 0, 1, 8, 0));
+    expect(result.end).toEqual(new Date(2024, 0, 1, 10, 0));
+  });
+
+  it("shrinks from end", () => {
+    const result = resize(meeting, "end", new Date(2024, 0, 1, 9, 30))!;
+    expect(result.start).toEqual(new Date(2024, 0, 1, 9, 0));
+    expect(result.end).toEqual(new Date(2024, 0, 1, 9, 30));
+  });
+
+  it("shrinks from start", () => {
+    const result = resize(meeting, "start", new Date(2024, 0, 1, 9, 45))!;
+    expect(result.start).toEqual(new Date(2024, 0, 1, 9, 45));
+    expect(result.end).toEqual(new Date(2024, 0, 1, 10, 0));
+  });
+
+  it("returns null when edges cross", () => {
+    expect(resize(meeting, "start", new Date(2024, 0, 1, 11, 0))).toBeNull();
+    expect(resize(meeting, "end", new Date(2024, 0, 1, 8, 0))).toBeNull();
+  });
+
+  it("allows zero-width result", () => {
+    const result = resize(meeting, "end", new Date(2024, 0, 1, 9, 0))!;
+    expect(result.start.getTime()).toBe(result.end.getTime());
+  });
+
+  it("returns type custom", () => {
+    expect(resize(meeting, "end", new Date(2024, 0, 1, 11, 0))!.type).toBe(
+      "custom"
+    );
+  });
+});

--- a/packages/minuta/src/operations/resize.ts
+++ b/packages/minuta/src/operations/resize.ts
@@ -1,0 +1,24 @@
+import type { TimePeriod } from "../types";
+
+/**
+ * Move one edge of a period while keeping the other fixed.
+ *
+ * Returns null if the new edge crosses the fixed edge.
+ *
+ * @example
+ * const meeting = createPeriod(new Date(2026, 2, 29, 9, 0), new Date(2026, 2, 29, 10, 0))
+ * resize(meeting, 'end', new Date(2026, 2, 29, 11, 30))
+ * // → { start: 9:00, end: 11:30, type: "custom" }
+ */
+export function resize(
+  period: TimePeriod,
+  edge: "start" | "end",
+  newDate: Date
+): TimePeriod | null {
+  const start = edge === "start" ? newDate : period.start;
+  const end = edge === "end" ? newDate : period.end;
+
+  if (start.getTime() > end.getTime()) return null;
+
+  return { start, end, type: "custom" };
+}


### PR DESCRIPTION
## Summary
Three new pure operations for calendar UI interactions:

- **`duration(period, unit?)`** — get period length in ms or complete units (hours, minutes, days, seconds)
- **`clamp(period, bounds)`** — constrain a period within boundaries, returns null if entirely outside
- **`resize(period, edge, date)`** — move start or end edge, returns null if edges cross

All pure functions, no adapter needed. 20 new tests. Exported from `minuta` and `minuta/operations`.

Closes #73, closes #74, closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)