### PR TITLE
feat: add equals() and strictEquals()

### DIFF
--- a/packages/minuta/src/index.ts
+++ b/packages/minuta/src/index.ts
@@ -5,6 +5,8 @@ export {
   previous,
   go,
   contains,
+  equals,
+  strictEquals,
   derivePeriod,
   createPeriod,
   split,

--- a/packages/minuta/src/operations.ts
+++ b/packages/minuta/src/operations.ts
@@ -8,6 +8,8 @@
  */
 export {
   contains,
+  equals,
+  strictEquals,
   gap,
   divide,
   go,

--- a/packages/minuta/src/operations/equals.test.ts
+++ b/packages/minuta/src/operations/equals.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { equals, strictEquals } from "./equals";
+import { createPeriod } from "./period";
+import type { Period, TimePeriod } from "../types";
+
+describe("equals", () => {
+  const jan1 = new Date(2024, 0, 1);
+  const jan31 = new Date(2024, 0, 31, 23, 59, 59, 999);
+
+  it("same period → true", () => {
+    const p = createPeriod(jan1, jan31);
+    expect(equals(p, p)).toBe(true);
+  });
+
+  it("same range, different types → true", () => {
+    const month: TimePeriod = { start: jan1, end: jan31, type: "month" };
+    const custom: TimePeriod = { start: jan1, end: jan31, type: "custom" };
+    expect(equals(month, custom)).toBe(true);
+  });
+
+  it("off by 1ms → false", () => {
+    const a = createPeriod(jan1, jan31);
+    const b = createPeriod(jan1, new Date(jan31.getTime() - 1));
+    expect(equals(a, b)).toBe(false);
+  });
+
+  it("different start → false", () => {
+    const a = createPeriod(jan1, jan31);
+    const b = createPeriod(new Date(2024, 0, 2), jan31);
+    expect(equals(a, b)).toBe(false);
+  });
+
+  it("zero-length periods at same instant → true", () => {
+    const a = createPeriod(jan1, jan1);
+    const b = createPeriod(jan1, jan1);
+    expect(equals(a, b)).toBe(true);
+  });
+
+  it("zero-length periods at different instants → false", () => {
+    const a = createPeriod(jan1, jan1);
+    const b = createPeriod(jan31, jan31);
+    expect(equals(a, b)).toBe(false);
+  });
+
+  it("works with PeriodSeries", () => {
+    const series: Period = {
+      start: jan1,
+      end: jan31,
+      type: "stableMonth",
+      meta: { weekStartsOn: 1, monthStart: jan1 },
+    };
+    const custom = createPeriod(jan1, jan31);
+    expect(equals(series, custom)).toBe(true);
+  });
+});
+
+describe("strictEquals", () => {
+  const jan1 = new Date(2024, 0, 1);
+  const jan31 = new Date(2024, 0, 31, 23, 59, 59, 999);
+
+  it("same range and type → true", () => {
+    const a: TimePeriod = { start: jan1, end: jan31, type: "month" };
+    const b: TimePeriod = { start: jan1, end: jan31, type: "month" };
+    expect(strictEquals(a, b)).toBe(true);
+  });
+
+  it("same range, different type → false", () => {
+    const a: TimePeriod = { start: jan1, end: jan31, type: "month" };
+    const b: TimePeriod = { start: jan1, end: jan31, type: "custom" };
+    expect(strictEquals(a, b)).toBe(false);
+  });
+
+  it("different range, same type → false", () => {
+    const a: TimePeriod = { start: jan1, end: jan31, type: "custom" };
+    const b: TimePeriod = {
+      start: jan1,
+      end: new Date(2024, 0, 15),
+      type: "custom",
+    };
+    expect(strictEquals(a, b)).toBe(false);
+  });
+});

--- a/packages/minuta/src/operations/equals.ts
+++ b/packages/minuta/src/operations/equals.ts
@@ -1,0 +1,24 @@
+import type { Period } from "../types";
+
+/**
+ * Check if two periods cover the exact same time range.
+ * Compares start and end timestamps only — ignores type.
+ *
+ * @example
+ * const jan = derivePeriod(adapter, date, "month")
+ * const custom = createPeriod(jan.start, jan.end)
+ * equals(jan, custom) // true
+ */
+export function equals(a: Period, b: Period): boolean {
+  return (
+    a.start.getTime() === b.start.getTime() &&
+    a.end.getTime() === b.end.getTime()
+  );
+}
+
+/**
+ * Check if two periods cover the exact same time range AND have the same type.
+ */
+export function strictEquals(a: Period, b: Period): boolean {
+  return equals(a, b) && a.type === b.type;
+}

--- a/packages/minuta/src/operations/index.ts
+++ b/packages/minuta/src/operations/index.ts
@@ -1,4 +1,5 @@
 export { contains } from "./contains";
+export { equals, strictEquals } from "./equals";
 export { derivePeriod, createPeriod } from "./period";
 export { gap } from "./gap";
 export { divide } from "./divide";


### PR DESCRIPTION
## Summary
- `equals(a, b)` — true if same time range, ignores type
- `strictEquals(a, b)` — true if same time range AND same type
- Pure timestamp comparison, no adapter needed
- 10 tests: same period, different types, off-by-1ms, zero-length, PeriodSeries

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)