### PR TITLE
feat: add moveTo() operation

### DIFF
--- a/packages/minuta/src/index.ts
+++ b/packages/minuta/src/index.ts
@@ -10,6 +10,7 @@ export {
   go,
   isSame,
   merge,
+  moveTo,
   next,
   previous,
   resize,

--- a/packages/minuta/src/operations.ts
+++ b/packages/minuta/src/operations.ts
@@ -15,6 +15,7 @@ export {
   go,
   isSame,
   merge,
+  moveTo,
   next,
   derivePeriod,
   createPeriod,

--- a/packages/minuta/src/operations/index.ts
+++ b/packages/minuta/src/operations/index.ts
@@ -7,6 +7,7 @@ export { divide } from "./divide";
 export { go } from "./go";
 export { isSame } from "./isSame";
 export { merge } from "./merge";
+export { moveTo } from "./moveTo";
 export { next } from "./next";
 export { previous } from "./previous";
 export { resize } from "./resize";

--- a/packages/minuta/src/operations/moveTo.test.ts
+++ b/packages/minuta/src/operations/moveTo.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { moveTo } from "./moveTo";
+import { createPeriod } from "./period";
+
+describe("moveTo", () => {
+  it("relocates a period to a target date", () => {
+    const appointment = createPeriod(
+      new Date(2026, 2, 29, 9, 0),
+      new Date(2026, 2, 29, 10, 0)
+    );
+    const result = moveTo(appointment, new Date(2026, 3, 2, 14, 0));
+    expect(result.start).toEqual(new Date(2026, 3, 2, 14, 0));
+    expect(result.end).toEqual(new Date(2026, 3, 2, 15, 0));
+  });
+
+  it("preserves duration", () => {
+    const period = createPeriod(
+      new Date(2024, 0, 1, 0, 0),
+      new Date(2024, 0, 3, 12, 0)
+    );
+    const result = moveTo(period, new Date(2024, 5, 15, 8, 0));
+    const originalMs = period.end.getTime() - period.start.getTime();
+    const resultMs = result.end.getTime() - result.start.getTime();
+    expect(resultMs).toBe(originalMs);
+  });
+
+  it("returns type custom", () => {
+    const period = createPeriod(new Date(2024, 0, 1), new Date(2024, 0, 31));
+    expect(moveTo(period, new Date(2024, 5, 1)).type).toBe("custom");
+  });
+
+  it("handles zero-duration period", () => {
+    const point = createPeriod(
+      new Date(2024, 0, 1, 12, 0),
+      new Date(2024, 0, 1, 12, 0)
+    );
+    const result = moveTo(point, new Date(2024, 5, 15));
+    expect(result.start).toEqual(result.end);
+  });
+});

--- a/packages/minuta/src/operations/moveTo.ts
+++ b/packages/minuta/src/operations/moveTo.ts
@@ -1,0 +1,18 @@
+import type { TimePeriod } from "../types";
+
+/**
+ * Relocate a period to a target date, preserving its duration.
+ *
+ * @example
+ * const appointment = createPeriod(new Date(2026, 2, 29, 9, 0), new Date(2026, 2, 29, 10, 0))
+ * const relocated = moveTo(appointment, new Date(2026, 3, 2, 14, 0))
+ * // → { start: Apr 2 14:00, end: Apr 2 15:00, type: "custom" }
+ */
+export function moveTo(period: TimePeriod, targetDate: Date): TimePeriod {
+  const durationMs = period.end.getTime() - period.start.getTime();
+  return {
+    start: targetDate,
+    end: new Date(targetDate.getTime() + durationMs),
+    type: "custom",
+  };
+}


### PR DESCRIPTION
## Summary
- `moveTo(period, targetDate)` — relocate a period preserving its duration
- Pure function, no adapter needed
- Replaces closed #72 (rebased on current master)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)