### PR TITLE
feat: add snap() for interval grid snapping

### DIFF
--- a/packages/minuta/src/index.ts
+++ b/packages/minuta/src/index.ts
@@ -14,6 +14,7 @@ export {
   next,
   previous,
   resize,
+  snap,
   split,
 } from "./operations";
 

--- a/packages/minuta/src/operations.ts
+++ b/packages/minuta/src/operations.ts
@@ -21,5 +21,6 @@ export {
   createPeriod,
   previous,
   resize,
+  snap,
   split,
 } from "./operations/index";

--- a/packages/minuta/src/operations/index.ts
+++ b/packages/minuta/src/operations/index.ts
@@ -11,4 +11,5 @@ export { move } from "./move";
 export { next } from "./next";
 export { previous } from "./previous";
 export { resize } from "./resize";
+export { snap } from "./snap";
 export { split } from "./split";

--- a/packages/minuta/src/operations/snap.test.ts
+++ b/packages/minuta/src/operations/snap.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { snap } from "./snap";
+
+const MIN = 60_000;
+
+describe("snap", () => {
+  describe("nearest (default)", () => {
+    it("snaps to nearest 15min boundary", () => {
+      const result = snap(new Date("2024-03-15T10:37:00Z"), 15 * MIN);
+      expect(result).toEqual(new Date("2024-03-15T10:30:00Z"));
+    });
+
+    it("snaps up when closer to next boundary", () => {
+      const result = snap(new Date("2024-03-15T10:38:00Z"), 15 * MIN);
+      expect(result).toEqual(new Date("2024-03-15T10:45:00Z"));
+    });
+
+    it("already on boundary", () => {
+      const result = snap(new Date("2024-03-15T10:00:00Z"), 15 * MIN);
+      expect(result).toEqual(new Date("2024-03-15T10:00:00Z"));
+    });
+
+    it("snaps to nearest 30min", () => {
+      const result = snap(new Date("2024-03-15T10:37:00Z"), 30 * MIN);
+      expect(result).toEqual(new Date("2024-03-15T10:30:00Z"));
+    });
+
+    it("snaps to nearest 5min", () => {
+      const result = snap(new Date("2024-03-15T14:02:00Z"), 5 * MIN);
+      expect(result).toEqual(new Date("2024-03-15T14:00:00Z"));
+    });
+
+    it("snaps across midnight", () => {
+      const result = snap(new Date("2024-03-15T23:53:00Z"), 15 * MIN);
+      expect(result).toEqual(new Date("2024-03-16T00:00:00Z"));
+    });
+  });
+
+  describe("floor", () => {
+    it("always snaps to earlier boundary", () => {
+      const result = snap(new Date("2024-03-15T10:37:00Z"), 15 * MIN, "floor");
+      expect(result).toEqual(new Date("2024-03-15T10:30:00Z"));
+    });
+
+    it("stays on boundary", () => {
+      const result = snap(new Date("2024-03-15T10:45:00Z"), 15 * MIN, "floor");
+      expect(result).toEqual(new Date("2024-03-15T10:45:00Z"));
+    });
+
+    it("floors to 30min", () => {
+      const result = snap(new Date("2024-03-15T10:59:00Z"), 30 * MIN, "floor");
+      expect(result).toEqual(new Date("2024-03-15T10:30:00Z"));
+    });
+  });
+
+  describe("ceil", () => {
+    it("always snaps to later boundary", () => {
+      const result = snap(new Date("2024-03-15T10:31:00Z"), 15 * MIN, "ceil");
+      expect(result).toEqual(new Date("2024-03-15T10:45:00Z"));
+    });
+
+    it("stays on boundary", () => {
+      const result = snap(new Date("2024-03-15T10:30:00Z"), 15 * MIN, "ceil");
+      expect(result).toEqual(new Date("2024-03-15T10:30:00Z"));
+    });
+
+    it("ceils across midnight", () => {
+      const result = snap(new Date("2024-03-15T23:46:00Z"), 15 * MIN, "ceil");
+      expect(result).toEqual(new Date("2024-03-16T00:00:00Z"));
+    });
+  });
+
+  describe("1-hour intervals", () => {
+    const HOUR = 60 * MIN;
+
+    it("snaps to nearest hour", () => {
+      const result = snap(new Date("2024-03-15T10:29:00Z"), HOUR);
+      expect(result).toEqual(new Date("2024-03-15T10:00:00Z"));
+    });
+
+    it("snaps up past half hour", () => {
+      const result = snap(new Date("2024-03-15T10:31:00Z"), HOUR);
+      expect(result).toEqual(new Date("2024-03-15T11:00:00Z"));
+    });
+  });
+});

--- a/packages/minuta/src/operations/snap.ts
+++ b/packages/minuta/src/operations/snap.ts
@@ -1,0 +1,22 @@
+/**
+ * Snap a date to the nearest interval boundary.
+ *
+ * @param date - The date to snap
+ * @param intervalMs - Interval size in milliseconds
+ * @param mode - Rounding strategy: 'nearest' (default), 'floor', 'ceil'
+ *
+ * @example
+ * snap(new Date('2024-03-15T10:37:00'), 15 * 60000)          // → 10:45 (nearest)
+ * snap(new Date('2024-03-15T10:37:00'), 15 * 60000, 'floor') // → 10:30
+ * snap(new Date('2024-03-15T10:37:00'), 15 * 60000, 'ceil')  // → 10:45
+ */
+export function snap(
+  date: Date,
+  intervalMs: number,
+  mode: "nearest" | "floor" | "ceil" = "nearest"
+): Date {
+  const ms = date.getTime();
+  const roundFn =
+    mode === "floor" ? Math.floor : mode === "ceil" ? Math.ceil : Math.round;
+  return new Date(roundFn(ms / intervalMs) * intervalMs);
+}


### PR DESCRIPTION
## Summary
- `snap(date, intervalMs, mode?)` — round a date to the nearest interval boundary
- Modes: `'nearest'` (default), `'floor'`, `'ceil'`
- Pure ms math, no adapter needed
- 14 tests: 15min/30min/5min/1h intervals, floor/ceil/nearest, boundary cases, midnight crossing

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)